### PR TITLE
always use password override even if already set

### DIFF
--- a/hw_diag/utilities/auth.py
+++ b/hw_diag/utilities/auth.py
@@ -71,19 +71,19 @@ def write_password(password):
 
 def read_password():
     PASSWORD_OVERRIDE = os.getenv('PASSWORD_OVERRIDE', 'false')
-    try:
-        password_row = g.db.query(AuthKeyValue). \
+    if PASSWORD_OVERRIDE != "false":  # nosec
+        default_password = PASSWORD_OVERRIDE
+        password_row = write_password(default_password)
+        logging.info("Using password from override env var!")
+    else:
+        try:
+            password_row = g.db.query(AuthKeyValue). \
             filter(AuthKeyValue.key == 'password_hash'). \
             one()
-    except NoResultFound:
-        if PASSWORD_OVERRIDE != "false":  # nosec
-            default_password = PASSWORD_OVERRIDE
-            logging.info("Using password from override env var!")
-        else:
+        except NoResultFound:
             default_password = generate_default_password()
+            password_row = write_password(default_password)
             logging.info("No password override. Generating default!")
-
-        password_row = write_password(default_password)
     return password_row
 
 


### PR DESCRIPTION
will always use the override password first, then check if one is already set, then generate a default one if neither of those are true.

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

